### PR TITLE
Better tokens

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -58,8 +58,8 @@ fn parse_int_success(c: &mut Criterion) {
 
     let to_number = pmap(
         number_parser,
-        move |(negate, value): (Option<char>, Vec<char>)| {
-            let string: String = value.into_iter().collect();
+        move |(negate, value): (Option<char>, Vec<Token<char>>)| {
+            let string: String = value.into_iter().map(|c| c.value).collect();
             let number = string.parse::<i32>().unwrap();
             match negate {
                 Some(_) => -number,

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -56,17 +56,14 @@ fn parse_int_success(c: &mut Criterion) {
     let many_numbers = pmany(any_number);
     let number_parser = pthen(poptional(pchar('-')), many_numbers);
 
-    let to_number = pmap(
-        number_parser,
-        move |(negate, value): (Option<char>, Vec<Token<char>>)| {
-            let string: String = value.into_iter().map(|c| c.value).collect();
-            let number = string.parse::<i32>().unwrap();
-            match negate {
-                Some(_) => -number,
-                None => number,
-            }
-        },
-    );
+    let to_number = pmap(number_parser, move |(negate, value)| {
+        let string: String = value.value.into_iter().map(|c| c.value).collect();
+        let number = string.parse::<i32>().unwrap();
+        match negate.value {
+            Some(_) => -number,
+            None => number,
+        }
+    });
 
     c.bench_function("Parse int Success", |b| {
         b.iter(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,22 +4,31 @@ use parser_combinator::*;
 
 fn main() {
     let any_number = pany!('0', '1', '2', '3', '4', '5', '6', '7', '8', '9');
+    let pidentifier = pany!(
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+        's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+    );
+    let pws = || poptional(pany!(' ', '\n', '\t', '\r'));
+
     let many_numbers = pmany(any_number);
     let number_parser = pthen(poptional(pchar('-')), many_numbers);
+    let pnumber = pmap(number_parser, move |(negate, value)| {
+        let string: String = value.value.into_iter().map(|c| c.value).collect();
+        let number = string.parse::<i32>().unwrap();
+        match negate.value {
+            Some(_) => -number,
+            None => number,
+        }
+    });
 
-    let to_number = pmap(
-        number_parser,
-        move |(negate, value): (Option<char>, Vec<Token<char>>)| {
-            let string: String = value.into_iter().map(|c| c.value).collect();
-            let number = string.parse::<i32>().unwrap();
-            match negate {
-                Some(_) => -number,
-                None => number,
-            }
-        },
-    );
-
-    let result = to_number("123".into());
-
+    let let_binding = pleft(pthen(pstring("let"), pws()));
+    let let_binding = pright(pthen(let_binding, pidentifier));
+    let let_binding = pleft(pthen(let_binding, pws()));
+    let let_binding = pleft(pthen(let_binding, pchar('=')));
+    let let_binding = pleft(pthen(let_binding, pws()));
+    let let_binding = pthen(let_binding, pnumber);
+    let let_binding = pleft(pthen(let_binding, pws()));
+    let let_binding = pleft(pthen(let_binding, pchar(';')));
+    let result = let_binding("let x = 10;".into());
     println!("{:?}", result);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,8 @@ fn main() {
 
     let pvalue = por(pnumber, pbool);
 
+    let pvalue = pbetween(pchar('('), pvalue, pchar(')'));
+
     let let_binding = pleft(pthen(pstring("let"), pws()));
     let let_binding = pright(pthen(let_binding, pidentifier));
     let let_binding = pleft(pthen(let_binding, pws()));
@@ -43,6 +45,6 @@ fn main() {
     let let_binding = pleft(pthen(let_binding, pws()));
     let let_binding = pleft(pthen(let_binding, pchar(';')));
 
-    let result = let_binding("let x = true;".into());
+    let result = let_binding("let x = (true);".into());
     println!("{:?}", result);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ fn main() {
 
     let to_number = pmap(
         number_parser,
-        move |(negate, value): (Option<char>, Vec<char>)| {
-            let string: String = value.into_iter().collect();
+        move |(negate, value): (Option<char>, Vec<Token<char>>)| {
+            let string: String = value.into_iter().map(|c| c.value).collect();
             let number = string.parse::<i32>().unwrap();
             match negate {
                 Some(_) => -number,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,12 @@ mod parser_combinator;
 
 use parser_combinator::*;
 
+#[derive(Debug)]
+enum Value {
+    Number(i32),
+    Bool(bool),
+}
+
 fn main() {
     let any_number = pany!('0', '1', '2', '3', '4', '5', '6', '7', '8', '9');
     let pidentifier = pany!(
@@ -20,15 +26,23 @@ fn main() {
             None => number,
         }
     });
+    let pnumber = pmap(pnumber, |n| Value::Number(n));
+
+    let ptrue = pmap(pstring("true"), |_| true);
+    let pfalse = pmap(pstring("false"), |_| false);
+    let pbool = pmap(por(ptrue, pfalse), |b| Value::Bool(b));
+
+    let pvalue = por(pnumber, pbool);
 
     let let_binding = pleft(pthen(pstring("let"), pws()));
     let let_binding = pright(pthen(let_binding, pidentifier));
     let let_binding = pleft(pthen(let_binding, pws()));
     let let_binding = pleft(pthen(let_binding, pchar('=')));
     let let_binding = pleft(pthen(let_binding, pws()));
-    let let_binding = pthen(let_binding, pnumber);
+    let let_binding = pthen(let_binding, pvalue);
     let let_binding = pleft(pthen(let_binding, pws()));
     let let_binding = pleft(pthen(let_binding, pchar(';')));
-    let result = let_binding("let x = 10;".into());
+
+    let result = let_binding("let x = true;".into());
     println!("{:?}", result);
 }

--- a/src/parser_combinator.rs
+++ b/src/parser_combinator.rs
@@ -306,6 +306,14 @@ pub fn pright<'a, T, U>(
     }
 }
 
+pub fn pbetween<'a, T, U, V>(
+    parser1: impl Fn(ContinuationState<'a>) -> ParseResult<(Token<T>,Token<U>)>,
+    parser2: impl Fn(ContinuationState<'a>) -> ParseResult<(Token<U>,Token<V>)>,
+) -> impl Fn(ContinuationState<'a>) -> ParseResult<U> {
+    let parser = pthen(parser1, parser2);
+    let parser = pleft(parser);
+}
+
 mod tests {
     use super::*;
     #[test]

--- a/src/parser_combinator.rs
+++ b/src/parser_combinator.rs
@@ -307,11 +307,14 @@ pub fn pright<'a, T, U>(
 }
 
 pub fn pbetween<'a, T, U, V>(
-    parser1: impl Fn(ContinuationState<'a>) -> ParseResult<(Token<T>,Token<U>)>,
-    parser2: impl Fn(ContinuationState<'a>) -> ParseResult<(Token<U>,Token<V>)>,
+    parser1: impl Fn(ContinuationState<'a>) -> ParseResult<T>,
+    parser2: impl Fn(ContinuationState<'a>) -> ParseResult<U>,
+    parser3: impl Fn(ContinuationState<'a>) -> ParseResult<V>,
 ) -> impl Fn(ContinuationState<'a>) -> ParseResult<U> {
-    let parser = pthen(parser1, parser2);
-    let parser = pleft(parser);
+    let parser = pthen(parser1, pthen(parser2, parser3));
+    let parser = pright(parser); //Skip T
+    let parser = pleft(parser); //Ignore U
+    parser
 }
 
 mod tests {


### PR DESCRIPTION
Example of a successful parse

`Ok((Token { value: (Token { value: 'x', start: 4, length: 1 }, Token { value: Bool(true), start: 9, length: 4 }), start: 4, length: 5 }, ContinuationState { remaining: "", position: 15, line_number: 0, line_position: 15 }))`

Each parsed token carries its location. 

Also fixed some small bugs regarding positions position in pmany and implemented pleft, pright and pbetween