### PR TITLE
Implement Sepby

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,12 @@ enum Value {
 
 fn main() {
     let any_number = pany(&['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
-    let pidentifier = pany(&[
-        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
-        's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-    ]);
+    let pidentifier = || {
+        pany(&[
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
+            'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+        ])
+    };
     let pws = || poptional(pany(&[' ', '\n', '\t', '\r']));
 
     let many_numbers = pmany1(any_number);
@@ -37,7 +39,7 @@ fn main() {
     let pvalue = pbetween(pchar('('), pvalue, pchar(')'));
 
     let let_binding = pleft(pthen(pstring("let"), pws()));
-    let let_binding = pright(pthen(let_binding, pidentifier));
+    let let_binding = pright(pthen(let_binding, pidentifier()));
     let let_binding = pleft(pthen(let_binding, pws()));
     let let_binding = pleft(pthen(let_binding, pchar('=')));
     let let_binding = pleft(pthen(let_binding, pws()));
@@ -45,6 +47,31 @@ fn main() {
     let let_binding = pleft(pthen(let_binding, pws()));
     let let_binding = pleft(pthen(let_binding, pchar(';')));
 
-    let result = let_binding("let x = (furn);".into());
+    let param_binding = pthen(pidentifier(), pws());
+    let param_binding = pleft(pthen(param_binding, pchar(':')));
+    let param_binding = pleft(pthen(param_binding, pws()));
+    let param_binding = pthen(param_binding, pidentifier());
+
+    let fun_binding = pleft(pthen(pstring("fun"), pws()));
+    let fun_binding = pright(pthen(fun_binding, pidentifier()));
+    let fun_binding = pleft(pthen(fun_binding, pws()));
+    let fun_binding = pleft(pthen(fun_binding, pchar('(')));
+    let fun_binding = pleft(pthen(fun_binding, pws()));
+    let fun_binding = pthen(fun_binding, psepby(|| param_binding, pchar(',')));
+    let fun_binding = pleft(pthen(fun_binding, pws()));
+    let fun_binding = pleft(pthen(fun_binding, pchar(')')));
+    let fun_binding = pleft(pthen(fun_binding, pws()));
+    let fun_binding = pleft(pthen(fun_binding, pchar('{')));
+    let fun_binding = pleft(pthen(fun_binding, pws()));
+    let fun_binding = pthen(fun_binding, pmany(let_binding));
+
+    let result = fun_binding(
+        "fun f(x: y) {
+            let x = 1;  
+        }"
+        .into(),
+    );
+    //let result = let_binding("let x = (furn);".into());
+
     println!("{:?}", result);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ fn main() {
     let let_binding = pthen(let_binding, pvalue);
     let let_binding = pleft(pthen(let_binding, pws()));
     let let_binding = pleft(pthen(let_binding, pchar(';')));
+    let let_binding = pleft(pthen(let_binding, pws()));
 
     let fun_binding = pleft(pthen(pstring("fun"), pws()));
     let fun_binding = pright(pthen(fun_binding, pidentifier()));
@@ -53,8 +54,9 @@ fn main() {
     let fun_binding = pleft(pthen(fun_binding, pchar('}')));
 
     let result = fun_binding(
-        "fun f(x: y) {
-            let x = 1;  
+        "fun n(x: y) {
+            let x = 1; 
+            let y = 2;   
         }"
         .into(),
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,6 @@ enum Value {
 
 fn main() {
     let any_number = pany(&['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
-    let pidentifier = || {
-        pany(&[
-            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
-            'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-        ])
-    };
-    let pws = || poptional(pany(&[' ', '\n', '\t', '\r']));
-
     let many_numbers = pmany1(any_number);
     let number_parser = pthen(poptional(pchar('-')), many_numbers);
     let pnumber = pmap(number_parser, move |(negate, value)| {
@@ -36,8 +28,6 @@ fn main() {
 
     let pvalue = por(pnumber, pbool);
 
-    let pvalue = pbetween(pchar('('), pvalue, pchar(')'));
-
     let let_binding = pleft(pthen(pstring("let"), pws()));
     let let_binding = pright(pthen(let_binding, pidentifier()));
     let let_binding = pleft(pthen(let_binding, pws()));
@@ -47,23 +37,20 @@ fn main() {
     let let_binding = pleft(pthen(let_binding, pws()));
     let let_binding = pleft(pthen(let_binding, pchar(';')));
 
-    let param_binding = pthen(pidentifier(), pws());
-    let param_binding = pleft(pthen(param_binding, pchar(':')));
-    let param_binding = pleft(pthen(param_binding, pws()));
-    let param_binding = pthen(param_binding, pidentifier());
-
     let fun_binding = pleft(pthen(pstring("fun"), pws()));
     let fun_binding = pright(pthen(fun_binding, pidentifier()));
     let fun_binding = pleft(pthen(fun_binding, pws()));
     let fun_binding = pleft(pthen(fun_binding, pchar('(')));
     let fun_binding = pleft(pthen(fun_binding, pws()));
-    let fun_binding = pthen(fun_binding, psepby(|| param_binding, pchar(',')));
+    let fun_binding = pthen(fun_binding, psepby(param_binding, pchar(',')));
     let fun_binding = pleft(pthen(fun_binding, pws()));
     let fun_binding = pleft(pthen(fun_binding, pchar(')')));
     let fun_binding = pleft(pthen(fun_binding, pws()));
     let fun_binding = pleft(pthen(fun_binding, pchar('{')));
     let fun_binding = pleft(pthen(fun_binding, pws()));
     let fun_binding = pthen(fun_binding, pmany(let_binding));
+    let fun_binding = pleft(pthen(fun_binding, pws()));
+    let fun_binding = pleft(pthen(fun_binding, pchar('}')));
 
     let result = fun_binding(
         "fun f(x: y) {
@@ -71,7 +58,26 @@ fn main() {
         }"
         .into(),
     );
-    //let result = let_binding("let x = (furn);".into());
 
     println!("{:?}", result);
+}
+
+fn pidentifier<'a>() -> impl Fn(ContinuationState<'a>) -> ParseResult<char> {
+    pany(&[
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+        's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    ])
+}
+
+fn pws<'a>() -> impl Fn(ContinuationState<'a>) -> ParseResult<'a, Vec<Token<char>>> {
+    pmany(pany(&[' ', '\n', '\t', '\r']))
+}
+
+fn param_binding<'a>() -> impl Fn(ContinuationState<'a>) -> ParseResult<(Token<char>, Token<char>)>
+{
+    let param_binding = pleft(pthen(pidentifier(), pws()));
+    let param_binding = pleft(pthen(param_binding, pchar(':')));
+    let param_binding = pleft(pthen(param_binding, pws()));
+    let param_binding = pthen(param_binding, pidentifier());
+    param_binding
 }

--- a/src/parser_combinator.rs
+++ b/src/parser_combinator.rs
@@ -851,4 +851,12 @@ mod tests {
         ));
         assert_eq!(result, expected);
     }
+
+    #[test]
+    fn test_psepby_missing_trail() {
+        let parser = psepby(|| pchar('1'), pchar(','));
+        let result = parser("1,1,".into());
+        let expected = Err(Error::new("1".to_string(), "".to_string(), 4, 0, 4));
+        assert_eq!(result, expected);
+    }
 }


### PR DESCRIPTION
The implementation is a bit awkward as we use the parser before the separator, then try to reuse it. 

We can't pass in a borrowed ref. 
We can't copy/clone a closure

So We pass a function that returns the closure. 

Awkward, but works for now