### PR TITLE
Finalize design for recursive parsers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,14 @@ use ngl::parser_combinator::*;
 use ngl::untyped_language::*;
 
 fn main() {
-    let fun_binding = pfun();
+    let fun_binding = pmany(pfun());
 
     let start = std::time::Instant::now();
 
     let result = fun_binding.parse(
-        "fun name(param: type, paramx: typex) {
+        "fun name(param: type, param_x: type_x) {
             let x = 1;
-            call(x, 2, function(3,4));
+            call(x, param, function(3,4));
             
         }"
         .into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
     let result = fun_binding.parse(
         "fun name(param: type, paramx: typex) {
             let x = 1;
-            call(1, 2, function(3,4));
+            call(x, 2, function(3,4));
             
         }"
         .into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
     let result = fun_binding.parse(
         "fun name(param: type, paramx: typex) {
             let x = 1;
-            call(x, y, 3);
+            call(x, y, function(a,b));
             let result = x;
         }"
         .into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ fn main() {
     let result = fun_binding.parse(
         "fun name(param: type, paramx: typex) {
             let x = 1;
-            call(x, y, function(a,b));
-            let result = x;
+            call(1, 2, function(3,4));
+            
         }"
         .into(),
     );

--- a/src/parser_combinator/error.rs
+++ b/src/parser_combinator/error.rs
@@ -3,7 +3,7 @@ use std::{
     ops::Add,
 };
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub struct Error {
     pub expected: String,
     pub actual: String,

--- a/src/parser_combinator/parser.rs
+++ b/src/parser_combinator/parser.rs
@@ -396,16 +396,16 @@ pub fn pchoice<'a, T: Clone + 'a>(parsers: Vec<impl Parser<'a, T>>) -> impl Pars
 }
 
 #[macro_export]
-macro_rules! pchoice_macro {
+macro_rules! pchoice {
     ($head:expr) => ({
-        move |input| $head.parse(input) //TODO - we should accumulate the errors for choice (ie "a" or "b" )
+        ClosureParser::new(move |input| $head.parse(input))
     });
     ($head:expr, $($tail:expr),*) => ({
         ClosureParser::new(
         move |input| {
             let result1 = $head.parse(input);
             result1.or_else(|error1|{
-                let result = pchoice_macro!($($tail),*)(input);
+                let result = pchoice!($($tail),*).parse(input);
                 result.map_err(|error2| error1 + error2)
             })
         })});

--- a/src/parser_combinator/parser.rs
+++ b/src/parser_combinator/parser.rs
@@ -17,7 +17,7 @@ where
     _phantom: std::marker::PhantomData<&'a Output>,
 }
 
-impl<'a, Output:Clone + 'a, F:Clone> ClosureParser<'a, Output, F>
+impl<'a, Output: Clone + 'a, F: Clone> ClosureParser<'a, Output, F>
 where
     F: Fn(ContinuationState<'a>) -> ParseResult<'a, Output>,
 {

--- a/src/parser_combinator/tests.rs
+++ b/src/parser_combinator/tests.rs
@@ -276,6 +276,20 @@ fn test_pchoice_fail() {
 }
 
 #[test]
+fn test_pchoice_fail_macro() {
+    let parser = pchoice!(pchar('a'), pchar('b'), pchar('c'));
+    let result = parser.parse("d".into());
+    let expected = Err(Error::new(
+        "a or b or c".to_string(),
+        "d".to_string(),
+        0,
+        0,
+        0,
+    ));
+    assert_eq!(result, expected);
+}
+
+#[test]
 fn test_pany_success() {
     let parser = pany(&['a', 'b', 'c']);
     let result = parser.parse("b".into());

--- a/src/parser_combinator/tests.rs
+++ b/src/parser_combinator/tests.rs
@@ -247,11 +247,10 @@ fn test_correct_line_number_on_error() {
     assert_eq!(result, expected);
 }
 
-/*
 #[test]
 fn test_pchoice_success() {
-    let parser = pchoice!(pchar('a'), pchar('b'));
-    let result = parser("a".into());
+    let parser = pchoice(vec![pchar('a'), pchar('b')]);
+    let result = parser.parse("a".into());
     let expected = Ok((
         Token {
             value: 'a',
@@ -270,11 +269,11 @@ fn test_pchoice_success() {
 
 #[test]
 fn test_pchoice_fail() {
-    let parser = pchoice!(pchar('a'), pchar('b'));
-    let result = parser("c".into());
+    let parser = pchoice(vec![pchar('a'), pchar('b')]);
+    let result = parser.parse("c".into());
     let expected = Err(Error::new("a or b".to_string(), "c".to_string(), 0, 0, 0));
     assert_eq!(result, expected);
-}*/
+}
 
 #[test]
 fn test_pany_success() {

--- a/src/untyped_language/language_parser.rs
+++ b/src/untyped_language/language_parser.rs
@@ -105,10 +105,10 @@ pub fn plet<'a>() -> impl Parser<'a, ExprOrStatement> {
 }
 
 pub fn pexpr<'a>() -> impl Parser<'a, Expr> {
-    let ident = pmap(pidentifier(), Expr::Ident);
+    //let ident = pmap(pidentifier(), Expr::Ident);
     let value = pmap(pvalue(), Expr::Value);
-    pchoice_macro!(value, ident)
-    //por(value, ident)
+    pchoice_macro!(value, pcall()) //, pmap(pidentifier(), Expr::Ident))
+                                   //por(value, ident)
 }
 
 pub fn pcall<'a>() -> impl Parser<'a, Expr> {

--- a/src/untyped_language/language_parser.rs
+++ b/src/untyped_language/language_parser.rs
@@ -1,5 +1,5 @@
 use crate::parser_combinator::*;
-use crate::pchoice_macro;
+use crate::pchoice;
 
 use super::*;
 
@@ -105,10 +105,8 @@ pub fn plet<'a>() -> impl Parser<'a, ExprOrStatement> {
 }
 
 pub fn pexpr<'a>() -> impl Parser<'a, Expr> {
-    //let ident = pmap(pidentifier(), Expr::Ident);
     let value = pmap(pvalue(), Expr::Value);
-    pchoice_macro!(value, pcall()) //, pmap(pidentifier(), Expr::Ident))
-                                   //por(value, ident)
+    pchoice!(value, pcall(), pmap(pidentifier(), Expr::Ident))
 }
 
 pub fn pcall<'a>() -> impl Parser<'a, Expr> {


### PR DESCRIPTION
Sometimes we need parses that are recursive 

for example 

`call_function(call_function(1), 1)`

The first parameter is an expr the 2nd is. Because Opaque types make this tricky, a macro can be used to expand the parsers in a closure that then gets converted to a parser. 