### PR TITLE
Improve speed of errors

### DIFF
--- a/src/parser_combinator/error.rs
+++ b/src/parser_combinator/error.rs
@@ -81,10 +81,10 @@ impl<'a> Display for Expected<'a> {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct Error<'a> {
     pub expected: Expected<'a>,
-    pub actual: String,
+    pub actual: &'a str,
     pub position: usize,
     pub line_number: usize,
     pub line_position: usize,
@@ -93,7 +93,7 @@ pub struct Error<'a> {
 impl<'a> Error<'a> {
     pub fn new(
         expected: Expected<'a>,
-        actual: String,
+        actual: &'a str,
         position: usize,
         line_number: usize,
         line_position: usize,
@@ -136,7 +136,7 @@ impl<'a> Add for Error<'a> {
 
     fn add(self, other: Error<'a>) -> Self::Output {
         let expected = self.expected + other.expected;
-        let actual = other.actual.clone();
+        let actual = other.actual;
         let position = other.position;
         let line_number = other.line_number;
         let line_position = other.line_position;

--- a/src/parser_combinator/parsers/any_parser.rs
+++ b/src/parser_combinator/parsers/any_parser.rs
@@ -14,7 +14,11 @@ impl<'a> Parser<'a, char> for AnyParser<'a> {
             }
         }
 
-        let actual = input.remaining.chars().next().unwrap_or(' ').to_string();
+        let actual = if !input.remaining.is_empty() {
+            &input.remaining[0..1]
+        } else {
+            " "
+        };
 
         Err(Error::new(
             self.valid_chars.into(),

--- a/src/parser_combinator/parsers/any_range_parser.rs
+++ b/src/parser_combinator/parsers/any_range_parser.rs
@@ -16,8 +16,11 @@ impl<'a> Parser<'a, char> for AnyRangeParser {
             }
         }
 
-        let actual = next_char.unwrap_or(' ').to_string();
-
+        let actual = if !input.remaining.is_empty() {
+            &input.remaining[0..1]
+        } else {
+            " "
+        };
         Err(Error::new(
             self.valid_chars.clone().into(),
             actual,

--- a/src/parser_combinator/parsers/at_least_one_parser.rs
+++ b/src/parser_combinator/parsers/at_least_one_parser.rs
@@ -20,7 +20,7 @@ where
                 if token.length == 0 {
                     Err(Error::new(
                         "1 or more".into(),
-                        cont.remaining.to_string(),
+                        cont.remaining,
                         input.position,
                         input.line_number,
                         input.line_position,

--- a/src/parser_combinator/parsers/char_parser.rs
+++ b/src/parser_combinator/parsers/char_parser.rs
@@ -7,16 +7,16 @@ pub(crate) fn pchar_impl(c: char, input: ContinuationState<'_>) -> ParseResult<'
             let parser_state = input.advance(1, letter == '\n');
             Ok((Token::new(c, input.position, 1), parser_state))
         }
-        Some(letter) => Err(Error::new(
+        Some(_) => Err(Error::new(
             c.into(),
-            letter.to_string(),
+            &input.remaining[0..1],
             input.position,
             input.line_number,
             input.line_position,
         )),
         None => Err(Error::new(
             c.into(),
-            "".to_string(),
+            "",
             input.position,
             input.line_number,
             input.line_position,

--- a/src/parser_combinator/parsers/string_parser.rs
+++ b/src/parser_combinator/parsers/string_parser.rs
@@ -16,14 +16,14 @@ impl<'a> Parser<'a, &'a str> for StringParser<'a> {
                 Err(err) => {
                     let length = err.position - input.position + 1;
                     let actual = if input.remaining.len() < length {
-                        input.remaining[0..].to_string()
+                        &input.remaining[0..]
                     } else {
-                        input.remaining[0..length].to_string()
+                        &input.remaining[0..length]
                     };
 
                     error = Some(Err(Error::new(
                         self.value.into(),
-                        actual.to_string(),
+                        actual,
                         err.position,
                         err.line_number,
                         err.line_position,

--- a/src/parser_combinator/parsers/whitepace_parser.rs
+++ b/src/parser_combinator/parsers/whitepace_parser.rs
@@ -13,7 +13,11 @@ impl<'a> Parser<'a, ()> for WhitespaceParser {
             }
         }
 
-        let actual = next_char.unwrap_or(' ').to_string();
+        let actual = if !input.remaining.is_empty() {
+            &input.remaining[0..1]
+        } else {
+            " "
+        };
         Err(Error::new(
             Expected::Char(' '),
             actual,

--- a/src/parser_combinator/tests.rs
+++ b/src/parser_combinator/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 fn test_pchar_eof() {
     let parser = pchar('H');
     let result = parser.parse("".into());
-    let expected = Err(Error::new(Expected::Char('H'), "".to_string(), 0, 0, 0));
+    let expected = Err(Error::new(Expected::Char('H'), "", 0, 0, 0));
     assert_eq!(result, expected);
 }
 
@@ -11,7 +11,7 @@ fn test_pchar_eof() {
 fn test_pchar_wrong_letter() {
     let parser = pchar('H');
     let result = parser.parse("c".into());
-    let expected = Err(Error::new(Expected::Char('H'), "c".to_string(), 0, 0, 0));
+    let expected = Err(Error::new(Expected::Char('H'), "c", 0, 0, 0));
     assert_eq!(result, expected);
 }
 
@@ -121,7 +121,7 @@ fn test_por_success_fail() {
     let result = parser.parse("e".into());
     let expected = Err(Error::new(
         Expected::Or(Box::new('H'.into()), Box::new('h'.into())),
-        "e".to_string(),
+        "e",
         0,
         0,
         0,
@@ -194,7 +194,7 @@ fn test_poptional_success_with_failure() {
 fn test_pstring_eof() {
     let h_parser = pstring("Hello");
     let result = h_parser.parse("Hell".into());
-    let expected = Err(Error::new("Hello".into(), "Hell".to_string(), 4, 0, 4));
+    let expected = Err(Error::new("Hello".into(), "Hell", 4, 0, 4));
     assert_eq!(result, expected);
 }
 
@@ -202,7 +202,7 @@ fn test_pstring_eof() {
 fn test_pstring_wrong_letter() {
     let h_parser = pstring("Hello");
     let result = h_parser.parse("c".into());
-    let expected = Err(Error::new("Hello".into(), "c".to_string(), 0, 0, 0));
+    let expected = Err(Error::new("Hello".into(), "c", 0, 0, 0));
     assert_eq!(result, expected);
 }
 
@@ -211,7 +211,7 @@ fn test_pstring_wrong_letter_after_other_parse() {
     let parser1 = pchar('c').then(pchar('w'));
     let parser = parser1.then(pstring("Hello"));
     let result = parser.parse("cwrong".into());
-    let expected = Err(Error::new("Hello".into(), "r".to_string(), 2, 0, 2));
+    let expected = Err(Error::new("Hello".into(), "r", 2, 0, 2));
     assert_eq!(result, expected);
 }
 
@@ -240,7 +240,7 @@ fn test_pchar_followed_by_pstring_followed_by_failure() {
     let parser1 = pchar('c').then(pstring("Hello"));
     let parser = parser1.then(pchar('w'));
     let result = parser.parse("cHelloX".into());
-    let expected = Err(Error::new(Expected::Char('w'), "X".to_string(), 6, 0, 6));
+    let expected = Err(Error::new(Expected::Char('w'), "X", 6, 0, 6));
     assert_eq!(result, expected);
 }
 
@@ -249,7 +249,7 @@ fn test_correct_line_number_on_error() {
     let parser = pchar('\n').then(pchar('\n'));
     let parser = parser.then(pchar('a'));
     let result = parser.parse("\n\nb".into());
-    let expected = Err(Error::new(Expected::Char('a'), "b".to_string(), 2, 2, 0));
+    let expected = Err(Error::new(Expected::Char('a'), "b", 2, 2, 0));
     assert_eq!(result, expected);
 }
 
@@ -279,7 +279,7 @@ fn test_pchoice_fail() {
     let result = parser.parse("c".into());
     let expected = Err(Error::new(
         Expected::Or(Box::new('a'.into()), Box::new('b'.into())),
-        "c".to_string(),
+        "c",
         0,
         0,
         0,
@@ -296,7 +296,7 @@ fn test_pchoice_fail_macro() {
             Box::new('a'.into()),
             Box::new(Expected::Or(Box::new('b'.into()), Box::new('c'.into()))),
         ),
-        "d".to_string(),
+        "d",
         0,
         0,
         0,
@@ -348,7 +348,7 @@ fn test_pws_success() {
 fn test_pws_fail() {
     let parser = pws();
     let result = parser.parse("d".into());
-    let expected = Err(Error::new(Expected::Char(' '), "d".to_string(), 0, 0, 0));
+    let expected = Err(Error::new(Expected::Char(' '), "d", 0, 0, 0));
     assert_eq!(result, expected);
 }
 
@@ -357,7 +357,7 @@ fn test_pany_fail() {
     let chars = ['a', 'b', 'c'];
     let parser = pany(&chars);
     let result = parser.parse("d".into());
-    let expected = Err(Error::new(chars.into(), "d".to_string(), 0, 0, 0));
+    let expected = Err(Error::new(chars.into(), "d", 0, 0, 0));
     assert_eq!(result, expected);
 }
 
@@ -458,7 +458,7 @@ fn test_between() {
 fn test_pmany1() {
     let parser = pchar('1').many1();
     let result = parser.parse("0".into());
-    let expected = Err(Error::new("1 or more".into(), "0".to_string(), 0, 0, 0));
+    let expected = Err(Error::new("1 or more".into(), "0", 0, 0, 0));
 
     assert_eq!(result, expected);
 }
@@ -491,6 +491,6 @@ fn test_psepby() {
 fn test_psepby_missing_trail() {
     let parser = pchar('1').sep_by(pchar(','));
     let result = parser.parse("1,1,".into());
-    let expected = Err(Error::new(Expected::Char('1'), "".to_string(), 4, 0, 4));
+    let expected = Err(Error::new(Expected::Char('1'), "", 4, 0, 4));
     assert_eq!(result, expected);
 }

--- a/src/untyped_language/tests.rs
+++ b/src/untyped_language/tests.rs
@@ -238,7 +238,7 @@ fn test_identifier_fail() {
             )),
             Box::new('_'.into()),
         ),
-        "1".to_string(),
+        "1",
         0,
         0,
         0,


### PR DESCRIPTION
Error handling much faster. 

This doesnt sound like it should hit the happy case, but we geberate an error for many, or, etc and often discard it. The cost of creation is now much lower, so we can stress less. 

The benchmark comparison to NOM is now showing ~2x faster (not a strictly fair comparison, I use Vec, they use HashMap, etc), but a significant improvement over the initial 6x _slower_!